### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ jtime
 =====
 [![Build Status](https://travis-ci.org/mapmyfitness/jtime.png?branch=master)](https://travis-ci.org/mapmyfitness/jtime)
 [![Coverage Status](https://coveralls.io/repos/mapmyfitness/jtime/badge.png)](https://coveralls.io/r/mapmyfitness/jtime)
-[![PyPi version](https://pypip.in/v/jtime/badge.png)](https://crate.io/packages/jtime/)
-[![PyPi downloads](https://pypip.in/d/jtime/badge.png)](https://crate.io/packages/jtime/)
+[![PyPi version](https://img.shields.io/pypi/v/jtime.svg)](https://crate.io/packages/jtime/)
+[![PyPi downloads](https://img.shields.io/pypi/dm/jtime.svg)](https://crate.io/packages/jtime/)
 
 jtime - A simple tool that provides git-aware time-tracking against JIRA issues without having to leave the command-line.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20jtime))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `jtime`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.